### PR TITLE
Add navigation for prior EXEC SQL statements

### DIFF
--- a/exec-sql-parser-test.el
+++ b/exec-sql-parser-test.el
@@ -1,0 +1,27 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(ert-deftest exec-sql-get-prior-basic ()
+  (with-temp-buffer
+    (insert "int a;\nEXEC SQL SELECT * FROM dual;\nint b;\nEXEC SQL COMMIT;\nint c;\n")
+    (goto-char (point-max))
+    (let ((info (exec-sql-get-prior)))
+      (should info)
+      (should (equal (plist-get info :start) '(4 . 0)))
+      (should (equal (plist-get info :end) '(4 . 15))))))
+
+(ert-deftest exec-sql-goto-prior-move ()
+  (with-temp-buffer
+    (insert "int a;\nEXEC SQL SELECT * FROM dual;\nint b;\nEXEC SQL COMMIT;\nint c;\n")
+    (goto-char (point-max))
+    (exec-sql-goto-prior)
+    (should (= (line-number-at-pos (point)) 4))
+    (should (= (current-column) 0))))
+
+(ert-deftest exec-sql-get-prior-skip-comments ()
+  (with-temp-buffer
+    (insert "/*\nEXEC SQL SELECT * FROM dual;\n*/\nEXEC SQL COMMIT;\n")
+    (goto-char (point-max))
+    (let ((info (exec-sql-get-prior)))
+      (should info)
+      (should (equal (plist-get info :start) '(4 . 0))))))


### PR DESCRIPTION
## Summary
- add `exec-sql-get-prior` to retrieve metadata about the preceding EXEC SQL block
- add `exec-sql-goto-prior` to move point to the previous EXEC SQL block
- test prior navigation and comment skipping

## Testing
- `emacs --batch -l ert -l exec-sql-parser.el -l exec-sql-parser-test.el -f ert-run-tests-batch-and-exit`

------
https://chatgpt.com/codex/tasks/task_b_6897e36c367083268b447101007bf8ee