### PR TITLE
refactor: split parser tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+## Environment
+All code you write must be compatible with:
+- Python 3.2.5
+- Cygwin 1.7.29
+- Oracle 12c

--- a/tests/exec-sql-parser/test-exec-sql-get-prior.el
+++ b/tests/exec-sql-parser/test-exec-sql-get-prior.el
@@ -10,14 +10,6 @@
       (should (equal (plist-get info :start) '(4 . 0)))
       (should (equal (plist-get info :end) '(4 . 15))))))
 
-(ert-deftest exec-sql-goto-prior-move ()
-  (with-temp-buffer
-    (insert "int a;\nEXEC SQL SELECT * FROM dual;\nint b;\nEXEC SQL COMMIT;\nint c;\n")
-    (goto-char (point-max))
-    (exec-sql-goto-prior)
-    (should (= (line-number-at-pos (point)) 4))
-    (should (= (current-column) 0))))
-
 (ert-deftest exec-sql-get-prior-skip-comments ()
   (with-temp-buffer
     (insert "/*\nEXEC SQL SELECT * FROM dual;\n*/\nEXEC SQL COMMIT;\n")
@@ -25,3 +17,5 @@
     (let ((info (exec-sql-get-prior)))
       (should info)
       (should (equal (plist-get info :start) '(4 . 0))))))
+
+(provide 'test-exec-sql-get-prior)

--- a/tests/exec-sql-parser/test-exec-sql-goto-prior.el
+++ b/tests/exec-sql-parser/test-exec-sql-goto-prior.el
@@ -1,0 +1,12 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(ert-deftest exec-sql-goto-prior-move ()
+  (with-temp-buffer
+    (insert "int a;\nEXEC SQL SELECT * FROM dual;\nint b;\nEXEC SQL COMMIT;\nint c;\n")
+    (goto-char (point-max))
+    (exec-sql-goto-prior)
+    (should (= (line-number-at-pos (point)) 4))
+    (should (= (current-column) 0))))
+
+(provide 'test-exec-sql-goto-prior)

--- a/tests/test_exec_sql_parser.el
+++ b/tests/test_exec_sql_parser.el
@@ -1,0 +1,8 @@
+(require 'ert)
+(add-to-list 'load-path (expand-file-name ".." (file-name-directory load-file-name)))
+
+(let ((test-dir (file-name-directory load-file-name)))
+  (load (expand-file-name "exec-sql-parser/test-exec-sql-get-prior.el" test-dir))
+  (load (expand-file-name "exec-sql-parser/test-exec-sql-goto-prior.el" test-dir)))
+
+(ert-run-tests-batch-and-exit)


### PR DESCRIPTION
## Summary
- split exec-sql parser tests into function-specific files
- keep `test_exec_sql_parser.el` as the single entry point loading each suite

## Testing
- `emacs --batch -l tests/test_exec_sql_parser.el`


------
https://chatgpt.com/codex/tasks/task_b_6897e7803df883269a26ebc5b19aa126