### PR TITLE
Add comprehensive parser tests

### DIFF
--- a/tests/examples/complex.pc
+++ b/tests/examples/complex.pc
@@ -1,0 +1,26 @@
+#include <stdio.h>
+
+int main() {
+    EXEC SQL SELECT * FROM dual;
+    EXEC SQL include sqlca;
+    EXEC SQL
+      INSERT INTO emp(id, name)
+      VALUES (1, 'Alice')
+    ;
+    EXEC SQL EXECUTE IMMEDIATE 'DELETE FROM emp';
+    EXEC SQL EXECUTE
+      BEGIN
+        NULL;
+      END;
+    END-EXEC;
+    EXEC SQL BEGIN DECLARE SECTION;
+    int id;
+    EXEC SQL END DECLARE SECTION;
+    /* This is a comment with EXEC SQL SELECT 1 FROM dual; */
+    EXEC SQL
+      UPDATE emp
+      SET name = 'Bob'
+      WHERE id = 1
+    ;
+    return 0;
+}

--- a/tests/exec-sql-parser/test-exec-sql-count-remaining.el
+++ b/tests/exec-sql-parser/test-exec-sql-count-remaining.el
@@ -1,0 +1,20 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(defconst exec-sql-test-examples-dir
+  (expand-file-name "../examples" (file-name-directory load-file-name)))
+
+(ert-deftest exec-sql-count-remaining-basic ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "complex.pc" exec-sql-test-examples-dir))
+    (goto-char (point-min))
+    (should (= 5 (exec-sql-count-remaining)))
+    (goto-char (point-min))
+    (forward-line 15)
+    (let ((start (point)))
+      (goto-char (point-max))
+      (push-mark (point) t t)
+      (goto-char start)
+      (should (= 2 (exec-sql-count-remaining))))))
+
+(provide 'test-exec-sql-count-remaining)

--- a/tests/exec-sql-parser/test-exec-sql-goto-next.el
+++ b/tests/exec-sql-parser/test-exec-sql-goto-next.el
@@ -1,0 +1,17 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(defconst exec-sql-test-examples-dir
+  (expand-file-name "../examples" (file-name-directory load-file-name)))
+
+(ert-deftest exec-sql-goto-next-sequence ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "complex.pc" exec-sql-test-examples-dir))
+    (goto-char (point-min))
+    (let ((lines '()))
+      (while (exec-sql-goto-next)
+        (push (line-number-at-pos (point)) lines))
+      (setq lines (nreverse lines))
+      (should (equal lines '(4 5 6 10 11 14 15 16 18 20))))))
+
+(provide 'test-exec-sql-goto-next)

--- a/tests/exec-sql-parser/test-exec-sql-load-registry.el
+++ b/tests/exec-sql-parser/test-exec-sql-load-registry.el
@@ -1,0 +1,16 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(ert-deftest exec-sql-parser-load-registry-override ()
+  (let ((dir (make-temp-file "exec-sql-registry" t)))
+    (unwind-protect
+        (progn
+          (with-temp-file (expand-file-name ".exec-sql-parser" dir)
+            (insert "{\n  \"STATEMENT-Single-Line [1]\": {\"pattern\": \"^EXEC SQL CUSTOM\\\\b.*;\"}\n}"))
+          (let ((registry (exec-sql-parser-load-registry dir)))
+            (let* ((entry (assoc "STATEMENT-Single-Line [1]" registry))
+                   (pattern (plist-get (cdr entry) :pattern)))
+              (should (string= pattern "^EXEC SQL CUSTOM\\b.*;")))))
+      (delete-directory dir t))))
+
+(provide 'test-exec-sql-load-registry)

--- a/tests/test_exec_sql_parser.el
+++ b/tests/test_exec_sql_parser.el
@@ -2,7 +2,11 @@
 (add-to-list 'load-path (expand-file-name ".." (file-name-directory load-file-name)))
 
 (let ((test-dir (file-name-directory load-file-name)))
-  (load (expand-file-name "exec-sql-parser/test-exec-sql-get-prior.el" test-dir))
-  (load (expand-file-name "exec-sql-parser/test-exec-sql-goto-prior.el" test-dir)))
+  (dolist (test-file '("exec-sql-parser/test-exec-sql-get-prior.el"
+                      "exec-sql-parser/test-exec-sql-goto-prior.el"
+                      "exec-sql-parser/test-exec-sql-goto-next.el"
+                      "exec-sql-parser/test-exec-sql-count-remaining.el"
+                      "exec-sql-parser/test-exec-sql-load-registry.el"))
+    (load (expand-file-name test-file test-dir))))
 
 (ert-run-tests-batch-and-exit)


### PR DESCRIPTION
## Summary
- Add complex Pro*C example to drive parser edge-case tests
- Test exec-sql parser traversal, counting, and registry overrides

## Testing
- `emacs --batch -l tests/test_exec_sql_parser.el`
- `emacs --batch -l tests/test_exec_sql_format.el`


------
https://chatgpt.com/codex/tasks/task_b_6897fbbf02288326a71b109b822b8e89