### PR TITLE
Handle indented END-EXEC blocks in parser and tests

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -41,7 +41,7 @@
     ;; EXEC SQL EXECUTE forms ordered to avoid masking
     ("EXECUTE-Block"
       :pattern "^EXEC SQL EXECUTE\\s-*$"
-      :end-pattern "^END-EXEC;\\s-*$"
+      :end-pattern "^\\s-*END-EXEC;\\s-*$"
       :action #'identity)
     ("EXECUTE-Immediate-Multi"
       :pattern "^EXEC SQL EXECUTE IMMEDIATE\\b[^;]*$"

--- a/tests/exec-sql-parser/exec-sql-get-next.el
+++ b/tests/exec-sql-parser/exec-sql-get-next.el
@@ -5,8 +5,8 @@
   (expand-file-name "../examples" (file-name-directory load-file-name)))
 
 (ert-deftest exec-sql-get-next-traverses-examples ()
-  (dolist (spec '(("complex.pc" . (4 5 6 10 11))
-                  ("oracle+addtl.pc" . (4 7 8 13 14))))
+  (dolist (spec '(("complex.pc" . (4 5 6 10 11 16 18 20))
+                  ("oracle+addtl.pc" . (4 7 8 13 14 20 22 26 28))))
     (with-temp-buffer
       (insert-file-contents (expand-file-name (car spec) exec-sql-test-examples-dir))
       (goto-char (point-min))

--- a/tests/exec-sql-parser/exec-sql-goto-next.el
+++ b/tests/exec-sql-parser/exec-sql-goto-next.el
@@ -22,8 +22,6 @@
       (while (exec-sql-goto-next)
         (push (line-number-at-pos (point)) lines))
       (setq lines (nreverse lines))
-      (should (equal (car lines) 4))
-      (should (equal (car (last lines)) 29))
-      (should-not (memq 25 lines)))))
+      (should (equal lines '(4 7 8 9 13 14 15 18 19 20 21 22 23 26 27 28 29))))))
 
 (provide 'exec-sql-goto-next-test)


### PR DESCRIPTION
## Summary
- indent `oracle+addtl.pc`'s `END-EXEC;` to match its opening `EXEC SQL`
- allow parser to recognize `END-EXEC;` lines with leading spaces
- extend navigation test to cover all blocks in `complex.pc`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689815bbe8348326b2c419b54eef51a9