### PR TITLE
Fix exec-sql navigation over END markers

### DIFF
--- a/tests/exec-sql-parser/exec-sql-get-next.el
+++ b/tests/exec-sql-parser/exec-sql-get-next.el
@@ -6,7 +6,7 @@
 
 (ert-deftest exec-sql-get-next-traverses-examples ()
   (dolist (spec '(("complex.pc" . (4 5 6 10 11 16 18 20))
-                  ("oracle+addtl.pc" . (4 7 8 13 14 20 22 26 28))))
+                  ("oracle+addtl.pc" . (4 7 9 13 15 21 23 27 29))))
     (with-temp-buffer
       (insert-file-contents (expand-file-name (car spec) exec-sql-test-examples-dir))
       (goto-char (point-min))

--- a/tests/exec-sql-parser/exec-sql-goto-next.el
+++ b/tests/exec-sql-parser/exec-sql-goto-next.el
@@ -12,7 +12,7 @@
       (while (exec-sql-goto-next)
         (push (line-number-at-pos (point)) lines))
       (setq lines (nreverse lines))
-      (should (equal lines '(4 5 6 10 11 14 15 16 18 20))))))
+      (should (equal lines '(4 5 6 10 11 16 18 20))))))
 
 (ert-deftest exec-sql-goto-next-example-file ()
   (with-temp-buffer
@@ -22,6 +22,25 @@
       (while (exec-sql-goto-next)
         (push (line-number-at-pos (point)) lines))
       (setq lines (nreverse lines))
-      (should (equal lines '(4 7 8 9 13 14 15 18 19 20 21 22 23 26 27 28 29))))))
+      (should (equal lines '(4 7 9 13 15 21 23 27 29))))))
+
+(ert-deftest exec-sql-goto-next-execute-block-skips-end ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "basic/oracle+addtl.pc" exec-sql-test-examples-dir))
+    (goto-char (point-min))
+    (search-forward "EXEC SQL EXECUTE")
+    (goto-char (match-beginning 0))
+    (exec-sql-goto-next)
+    (should (looking-at "EXEC SQL INCLUDE"))))
+
+(ert-deftest exec-sql-goto-next-execute-block-skips-end-exec ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "basic/oracle+addtl.pc" exec-sql-test-examples-dir))
+    (goto-char (point-min))
+    (search-forward "EXEC SQL EXECUTE")
+    (goto-char (match-beginning 0))
+    (exec-sql-goto-next)
+    (exec-sql-goto-next)
+    (should (looking-at "EXEC SQL EXECUTE IMMEDIATE"))))
 
 (provide 'exec-sql-goto-next-test)


### PR DESCRIPTION
## Summary
- skip `:error` registry entries in `exec-sql-goto-next`
- account for newlines when computing statement offsets
- add regression tests for `EXECUTE` blocks to ensure `END` tokens are ignored

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68987a4a9b4c83268296a293cf17cf0e