### PR TITLE
Add SQL statement extraction utility and tests

### DIFF
--- a/exec-sql-parser.el
+++ b/exec-sql-parser.el
@@ -431,6 +431,34 @@ REGISTRY defaults to `exec-sql-parser-registry'."
       (message "%d" count))
     count))
 
+;;;###autoload
+(defun exec-sql-extract ()
+  "Create a new buffer with all EXEC SQL statements from the current buffer.
+
+The statements are separated by a line of equal signs prefixed by
+\"//\".  The resulting buffer is displayed and also returned."
+  (interactive)
+  (let ((dest (generate-new-buffer "*exec-sql-extract*"))
+        (sep (concat "//" (make-string 72 ?=) "\n"))
+        info start end block (first t))
+    (with-current-buffer dest
+      (erase-buffer))
+    (save-excursion
+      (goto-char (point-min))
+      (while (setq info (exec-sql-goto-next))
+        (setq start (+ (point-min) (plist-get info :offset)))
+        (setq end (+ start (plist-get info :length)))
+        (setq block (buffer-substring-no-properties start end))
+        (with-current-buffer dest
+          (unless first (insert sep))
+          (insert block "\n"))
+        (setq first nil)
+        (goto-char end)))
+    (with-current-buffer dest
+      (goto-char (point-min)))
+    (pop-to-buffer dest)
+    dest))
+
 (provide 'exec-sql-parser)
 
 ;;; exec-sql-parser.el ends here

--- a/tests/exec-sql-parser/exec-sql-extract.el
+++ b/tests/exec-sql-parser/exec-sql-extract.el
@@ -1,0 +1,29 @@
+(require 'ert)
+(require 'exec-sql-parser)
+
+(defconst exec-sql-test-examples-dir
+  (expand-file-name "../examples" (file-name-directory load-file-name)))
+
+(ert-deftest exec-sql-extract-basic ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "complex.pc" exec-sql-test-examples-dir))
+    (let ((count 0) info res)
+      (save-excursion
+        (goto-char (point-min))
+        (while (setq info (exec-sql-goto-next))
+          (setq count (1+ count))
+          (goto-char (+ (point-min)
+                        (plist-get info :offset)
+                        (plist-get info :length)))))
+      (setq res (exec-sql-extract))
+      (unwind-protect
+          (with-current-buffer res
+            (should (= (count-matches "^EXEC SQL" (point-min) (point-max))
+                       count))
+            (should (= (count-matches "^//=+" (point-min) (point-max))
+                       (1- count))))
+        (when (buffer-live-p res)
+          (kill-buffer res))))))
+
+(provide 'exec-sql-extract-test)
+


### PR DESCRIPTION
## Summary
- add `exec-sql-extract` to gather EXEC SQL blocks and display them in a new buffer separated by `//` comment lines of `=`
- cover extraction behavior with unit test

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68987f92ffe083269c495e6efc8a533a