### PR TITLE
Fix region formatting in exec-sql-format

### DIFF
--- a/exec-sql-format.el
+++ b/exec-sql-format.el
@@ -36,11 +36,11 @@
            formatted-sql-buffer
            nil ; do not replace region automatically
            "*SQL Format Errors*" t)
-          (with-current-buffer formatted-sql-buffer
-            (let ((formatted (buffer-string)))
-              (delete-region start end)
-              (goto-char start)
-              (insert formatted)))
+          (let ((formatted (with-current-buffer formatted-sql-buffer
+                              (buffer-string))))
+            (delete-region start end)
+            (goto-char start)
+            (insert formatted))
           (kill-buffer formatted-sql-buffer))
       (message "No region selected."))))
 

--- a/tests/exec-sql-format/exec-sql-format.el
+++ b/tests/exec-sql-format/exec-sql-format.el
@@ -28,6 +28,23 @@
         (should formatted)
         (should (looking-at "UPDATE EMP"))))))
 
+(ert-deftest exec-sql-format-select-region ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "oracle+addtl.pc" exec-sql-test-examples-dir))
+    (goto-char (point-min))
+    (forward-line 12) ; mark at start of line 13
+    (push-mark (point) t t)
+    (goto-char (point-min))
+    (forward-line 8) ; point at start of line 9
+    (cl-letf (((symbol-function 'shell-command-on-region)
+               (lambda (s e command output-buffer replace error-buffer display)
+                 (with-current-buffer (get-buffer-create output-buffer)
+                   (erase-buffer)
+                   (insert (upcase (buffer-substring s e)))))))
+      (exec-sql-format (region-beginning) (region-end))
+      (goto-char (region-beginning))
+      (should (looking-at "    EXEC SQL SELECT ID, NAME")))))
+
 (ert-deftest exec-sql-format-no-region ()
   (with-temp-buffer
     (insert "select * from dual;")


### PR DESCRIPTION
## Summary
- add regression test covering formatting of a selected EXEC SQL region
- fix exec-sql-format to replace text in the original buffer instead of the formatter's temp buffer

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6898d66cf5a88326ad373cee85f847a6