### PR TITLE
Use parser when counting remaining EXEC SQL statements

### DIFF
--- a/tests/exec-sql-parser/exec-sql-count-remaining.el
+++ b/tests/exec-sql-parser/exec-sql-count-remaining.el
@@ -8,19 +8,30 @@
   (with-temp-buffer
     (insert-file-contents (expand-file-name "complex.pc" exec-sql-test-examples-dir))
     (goto-char (point-min))
-    (should (= 5 (exec-sql-count-remaining)))
+    (should (= 8 (exec-sql-count-remaining)))
     (goto-char (point-min))
     (forward-line 15)
     (let ((start (point)))
       (goto-char (point-max))
       (push-mark (point) t t)
       (goto-char start)
-      (should (= 2 (exec-sql-count-remaining))))))
+      (should (= 3 (exec-sql-count-remaining))))))
 
 (ert-deftest exec-sql-count-remaining-oracle+addtl ()
   (with-temp-buffer
     (insert-file-contents (expand-file-name "oracle+addtl.pc" exec-sql-test-examples-dir))
     (goto-char (point-min))
-    (should (= 6 (exec-sql-count-remaining)))))
+    (should (= 9 (exec-sql-count-remaining)))))
+
+(ert-deftest exec-sql-count-remaining-comment-toggle ()
+  (with-temp-buffer
+    (c-mode)
+    (insert "/*\nEXEC SQL SELECT 1 FROM dual;\n*/\nEXEC SQL SELECT 1 FROM dual;\n")
+    (goto-char (point-min))
+    (let ((exec-sql-parser-ignore-comments t))
+      (should (= 1 (exec-sql-count-remaining))))
+    (goto-char (point-min))
+    (let ((exec-sql-parser-ignore-comments nil))
+      (should (= 2 (exec-sql-count-remaining))))))
 
 (provide 'exec-sql-count-remaining-test)


### PR DESCRIPTION
## Summary
- Count embedded SQL statements with `exec-sql-goto-next` so multi-line blocks are included
- Document and test comment handling for `exec-sql-count-remaining`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6898db6d7af48326abefbb2d085a358f