### PR TITLE
Add keystroke-driven external Emacs test for exec-sql-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-
-test: emacs-tests
+test: emacs-tests python-tests
 
 emacs-tests e-tests etest :
 	emacs --batch -l tests/test_exec_sql_parser.el
 	emacs --batch -l tests/test_exec_sql_format.el
+
+python-tests:
+	python3 tests/exec-sql-format/test_exec_sql_format_external.py

--- a/tests/exec-sql-format/test_exec_sql_format_external.py
+++ b/tests/exec-sql-format/test_exec_sql_format_external.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import os
+import pty
+import time
+
+FILE_PATH = os.path.join('tests', 'examples', 'oracle+addtl.pc')
+EXPECTED_FRAGMENT = (
+    'SELECT id,\n'
+    '       name INTO :v_id,\n'
+    '                 :v_name\n'
+    'FROM emp\n'
+    'WHERE id = 10;'
+)
+
+def main():
+    f = open(FILE_PATH, 'r')
+    original = f.read()
+    f.close()
+    path = os.path.abspath(FILE_PATH)
+    try:
+        pid, fd = pty.fork()
+        if pid == 0:
+            emacs = 'emacs-nox'
+            if os.system('which emacs-nox >/dev/null 2>&1') != 0:
+                emacs = 'emacs'
+            os.execvp(emacs, [emacs, '-Q', '-nw', '-L', '.', '-l', 'exec-sql-format.el', path])
+        else:
+            def send(data):
+                os.write(fd, data)
+                time.sleep(0.5)
+            send(b'\x1bg' + b'g9\r')
+            send(b'\x01')
+            send(b'\x00')
+            send(b'\x1bg' + b'g13\r')
+            send(b'\x05')
+            send(b'\x1bxexec-sql-format\r')
+            time.sleep(1)
+            send(b'\x18\x13')
+            send(b'\x18\x03')
+            os.waitpid(pid, 0)
+            f = open(FILE_PATH, 'r')
+            new_content = f.read()
+            f.close()
+            assert EXPECTED_FRAGMENT in new_content
+            print('external format test passed')
+    finally:
+        f = open(FILE_PATH, 'w')
+        f.write(original)
+        f.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- replace Lisp-based external `exec-sql-format` test with Python script that drives `emacs` via keystrokes
- run the new integration test from `make test`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68991c1cee6c832680576656ad6979fc