### PR TITLE
Normalize region bounds in exec-sql-format

### DIFF
--- a/exec-sql-format.el
+++ b/exec-sql-format.el
@@ -29,17 +29,18 @@
   (interactive "r")
   (let ((formatted-sql-buffer "*Formatted SQL*"))
     (if (use-region-p)
-        (progn
+        (let ((s (min start end))
+              (e (max start end)))
           (shell-command-on-region
-           start end
+           s e
            "sqlformat -r -k upper -s -"  ; change options here if needed
            formatted-sql-buffer
            nil ; do not replace region automatically
            "*SQL Format Errors*" t)
           (let ((formatted (with-current-buffer formatted-sql-buffer
                               (buffer-string))))
-            (delete-region start end)
-            (goto-char start)
+            (delete-region s e)
+            (goto-char s)
             (insert formatted))
           (kill-buffer formatted-sql-buffer))
       (message "No region selected."))))

--- a/issue/bad-format-region/001.txt
+++ b/issue/bad-format-region/001.txt
@@ -1,0 +1,2 @@
+exec-sql-format should format SQL even if called with reversed region boundaries.
+Currently, providing start greater than end leads to incorrect behavior.

--- a/issue/bad-format-region/DEBUG_LOG.md
+++ b/issue/bad-format-region/DEBUG_LOG.md
@@ -1,0 +1,65 @@
+# Debugging Log – Bad format region
+
+**Issue Reference:** `issue/bad-format-region/001.txt`  
+**Start Date:** 2025-08-11  
+**Current Status:** In Progress  
+
+---
+
+## Session Log
+
+### Session 2025-08-11
+**Objective:** Investigate failing tests and ensure `exec-sql-format` handles reversed region boundaries.
+
+**Steps Taken:**  
+1. Ran test suite to verify failures.  
+2. Added normalization of region bounds in `exec-sql-format`.  
+3. Added regression test for reversed region.  
+4. Re-ran tests to confirm all pass.
+
+**Commands Run / Observations:**  
+```bash
+make test
+```
+_Output:_  
+```
+   passed   8/10  exec-sql-format-no-region (0.000035 sec)
+   passed   9/10  exec-sql-format-reversed-region (0.000062 sec)
+No region selected.
+   passed  10/10  exec-sql-format-select-region (0.000191 sec)
+
+Ran 10 tests, 10 results as expected, 0 unexpected (2025-08-11 03:03:04+0000, 0.002174 sec)
+```
+
+**Reasoning / Analysis:**  
+- The test for reversed region was missing, so failures were not reproduced.  
+- Normalizing start/end with `min`/`max` prevents errors when start > end.  
+
+**Partial Findings:**  
+- All tests pass after normalization and new regression coverage.  
+
+**Remaining Issues:**  
+- None.  
+
+**Next Steps for Future Session:**  
+- Monitor for edge cases in interactive usage.  
+
+---
+
+## Summary of Progress
+- Key discoveries so far:  
+  - Need to normalize region bounds and add reversed region test.  
+- Current hypothesis:  
+  - Reordered bounds fully resolve the issue.  
+
+---
+
+## Resolution (fill after closing issue)
+**Final Fix Summary:**  
+-  
+
+**Tests Added/Updated:**  
+-  
+
+**Lessons Learned:**  
+-  

--- a/tests/exec-sql-format/exec-sql-format.el
+++ b/tests/exec-sql-format/exec-sql-format.el
@@ -26,7 +26,21 @@
         (exec-sql-format (point-min) (point-max))
         (goto-char (point-min))
         (should formatted)
-        (should (looking-at "UPDATE EMP"))))))
+  (should (looking-at "UPDATE EMP"))))))
+
+(ert-deftest exec-sql-format-reversed-region ()
+  (with-temp-buffer
+    (insert "select * from dual;")
+    (cl-letf* (((symbol-function 'use-region-p) (lambda () t))
+               ((symbol-function 'shell-command-on-region)
+                (lambda (s e command output-buffer replace error-buffer display)
+                  (let ((text (buffer-substring (min s e) (max s e))))
+                    (with-current-buffer (get-buffer-create output-buffer)
+                      (erase-buffer)
+                      (insert (upcase text)))))))
+      (exec-sql-format (point-max) (point-min))
+      (goto-char (point-min))
+      (should (looking-at "SELECT \\* FROM DUAL;")))))
 
 (ert-deftest exec-sql-format-select-region ()
   (with-temp-buffer


### PR DESCRIPTION
## Summary
- normalize region start/end in `exec-sql-format` to handle reversed inputs
- add regression test for reversed region
- track debugging progress in `issue/bad-format-region`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_689956ce0de8832689158403ea0fd5c5